### PR TITLE
Fixed windows_whl and linux_whl typo.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,9 +228,8 @@ jobs:
           python -m pip install twine
           python setup.py sdist --formats=gztar,zip
           rm -rf dist/artifacts/windows_build dist/artifacts/linux_build
-          ls dist/artifacts/windows_whl
-          mv dist/artifacts/windows_whl/* dist/
-          mv dist/artifacts/linux_whl/* dist/
+          mv dist/artifacts/windows-whl/* dist/
+          mv dist/artifacts/linux-whl/* dist/
           rm -rf dist/artifacts
       - name: Run Twine
         run: |


### PR DESCRIPTION
In the twine section, windows-whl and linux-whl were accidently misspelled as 'windows_whl' and 'linux_whl' respectively. This minuscule commit fixes that.